### PR TITLE
fix: add [proxy] extra to litellm install and bump to post-CVE v1.83.0

### DIFF
--- a/src/mlx_stack/core/deps.py
+++ b/src/mlx_stack/core/deps.py
@@ -90,6 +90,14 @@ class DependencyStatus:
 _console = Console(stderr=True)
 
 
+def _build_install_spec(tool: str, version: str) -> str:
+    """Build the pip/uv install specifier for a tool, including extras."""
+    extra = _TOOL_EXTRAS.get(tool)
+    if extra:
+        return f"{tool}[{extra}]=={version}"
+    return f"{tool}=={version}"
+
+
 def _find_binary(tool: str) -> str | None:
     """Return the full path to a tool's binary, or ``None`` if not found.
 
@@ -125,7 +133,7 @@ def _get_installed_version(tool: str) -> str | None:
     if result.returncode != 0:
         return None
 
-    # Parse lines like "vllm-mlx v0.2.6" or "litellm v1.67.2"
+    # Parse lines like "vllm-mlx v0.2.6" or "litellm v1.83.0"
     for line in result.stdout.splitlines():
         # Match "<tool> v<version>" pattern
         pattern = rf"^{re.escape(tool)}\s+v?(\S+)"
@@ -155,11 +163,7 @@ def _install_tool(tool: str, version: str) -> None:
         )
         raise DependencyError(msg)
 
-    extra = _TOOL_EXTRAS.get(tool)
-    if extra:
-        install_spec = f"{tool}[{extra}]=={version}"
-    else:
-        install_spec = f"{tool}=={version}"
+    install_spec = _build_install_spec(tool, version)
     cmd = [uv_path, "tool", "install", install_spec]
     cmd_str = f"uv tool install {install_spec}"
 
@@ -278,7 +282,7 @@ def ensure_dependency(tool: str) -> DependencyStatus:
 
         # Verify post-install
         if not _verify_post_install(tool):
-            cmd_str = f"uv tool install {tool}=={status.pinned_version}"
+            cmd_str = f"uv tool install {_build_install_spec(tool, status.pinned_version)}"
             msg = (
                 f"{tool} was not found on PATH after installation.\n"
                 f"This may be because the uv tool bin directory is not in your PATH.\n\n"
@@ -325,7 +329,7 @@ def _warn_version_mismatch(tool: str, status: DependencyStatus) -> None:
     """
     pinned = status.pinned_version
     installed = status.installed_version or "unknown"
-    cmd = f"uv tool install {tool}=={pinned}"
+    cmd = f"uv tool install {_build_install_spec(tool, pinned)}"
     _console.print(
         f"[yellow]⚠ {tool} version mismatch: "
         f"installed v{installed}, expected v{pinned}.[/yellow]\n"

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mlx_stack.core.deps import (
+    _TOOL_EXTRAS,
     PINNED_VERSIONS,
     DependencyError,
     DependencyInstallError,
@@ -569,7 +570,7 @@ class TestEnsureDependency:
         ensure_dependency("litellm")
 
         console_prints = [str(c) for c in mock_console.print.call_args_list]
-        cmd_found = any("uv tool install litellm==1.83.0" in p for p in console_prints)
+        cmd_found = any("uv tool install litellm[proxy]==1.83.0" in p for p in console_prints)
         assert cmd_found, f"Expected upgrade command in: {console_prints}"
 
     def test_unknown_tool_raises_value_error(self) -> None:
@@ -782,3 +783,14 @@ class TestEdgeCases:
 
         args = mock_subprocess_run.call_args[0][0]
         assert args[3] == "vllm-mlx==0.3.0rc1"
+
+
+class TestToolExtrasSync:
+    """Guard against _TOOL_EXTRAS drifting out of sync with PINNED_VERSIONS."""
+
+    def test_extras_keys_are_valid_tools(self) -> None:
+        """Every key in _TOOL_EXTRAS must also be in PINNED_VERSIONS."""
+        for tool in _TOOL_EXTRAS:
+            assert tool in PINNED_VERSIONS, (
+                f"_TOOL_EXTRAS has '{tool}' which is not in PINNED_VERSIONS"
+            )


### PR DESCRIPTION
## Summary

- Added `[proxy]` extra to litellm install spec — proxy server dependencies (`backoff`, `prisma`, etc.) were missing, causing `mlx-stack up` to crash with `ModuleNotFoundError`
- Bumped litellm pin from v1.67.2 to v1.83.0 (first verified-clean release after CVE-2026-33634)
- Added `_TOOL_EXTRAS` map in `deps.py` so extras are applied automatically during install
- Added regression tests: litellm install includes `[proxy]`, vllm-mlx install has no extras

Fixes #5

## Test plan

- [x] 1417 unit tests pass
- [x] Lint + typecheck clean
- [x] `test_litellm_installs_with_proxy_extra` asserts install command is `uv tool install litellm[proxy]==1.83.0`
- [x] `test_vllm_mlx_installs_without_extra` asserts no extras leak to other tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)