### PR TITLE
fix: pass explicit token to release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Release Please failed with `Error creating commit` because the `GITHUB_TOKEN` wasn't explicitly passed to the action
- Adds `token: ${{ secrets.GITHUB_TOKEN }}` to the action inputs
- Cleaned up the dangling `release-please--branches--main` branch from the failed run

## Test plan
- [ ] Merge this PR and verify Release Please successfully opens a release PR for v0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)