### PR TITLE
ci: add publish job to release-please and use GitHub-generated notes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,13 @@ jobs:
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ steps.release.outputs.tag_name }} --repo ${{ github.repository }} --generate-notes --notes ""
+        run: |
+          gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name=${{ steps.release.outputs.tag_name }} \
+            --jq '.body' \
+          | gh release edit ${{ steps.release.outputs.tag_name }} \
+              --repo ${{ github.repository }} \
+              --notes-file -
 
   ci:
     name: CI


### PR DESCRIPTION
## Summary
- Moves CI and publish jobs into the release-please workflow, conditioned on `release_created == true`
- Fixes the GITHUB_TOKEN limitation where releases created by `github-actions[bot]` don't trigger `publish.yml`
- After Release Please creates a release, regenerates the notes using GitHub's native auto-generated format (`.github/release.yml` categories) instead of Release Please's commit-list style

## How it works
1. Release Please runs on every push to main — opens/updates a release PR
2. When the release PR is merged, Release Please creates the tag + release
3. Same workflow then: regenerates notes → runs CI → publishes to PyPI

## Test plan
- [ ] Merge this PR — Release Please should open a release PR (for `ci:` commits, it won't — that's correct)
- [ ] On next `fix:` or `feat:` merge, verify the full chain: release PR → merge → tag + release with GitHub-style notes → CI → PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)